### PR TITLE
Initial implementation of the plugin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2015 Eric Thul
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), in the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to
+whom the Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# purescript-webpack-plugin
+
+> [PureScript](http://www.purescript.org) plugin for [webpack](http://webpack.github.io)
+
+## Install
+
+Install with [npm](https://npmjs.org/package/purescript-webpack-plugin).
+
+```
+npm install purescript-webpack-plugin --save-dev
+```
+
+## Options
+
+###### `src` (String Array)
+
+Specifies the PureScript source files. Glob syntax is supported. The default value is `[ 'src/**/*.purs', 'bower_components/purescript-*/src/**/*.purs' ]`.
+
+###### `ffi` (String Array)
+
+Specifies the PureScript FFI files. Glob syntax is supported. The default value is `[ 'src/**/*.js', 'bower_components/purescript-*/src/**/*.js' ]`.
+
+###### `output` (String)
+
+Specifies the PureScript output path. The default value is `output`.
+
+###### `bundleOutput` (String)
+
+Specifies the PureScript bundle output path. The default value is `output/bundle.js`.
+
+###### `bundleNamespace` (String)
+
+Specifies the PureScript bundle namespace. The default value is `PS`.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,174 @@
+'use strict';
+
+var path = require('path');
+
+var fs = require('fs');
+
+var child_process = require('child_process');
+
+var PSC = 'psc';
+
+var PSC_BUNDLE = 'psc-bundle';
+
+var REQUIRE_PATH = '../';
+
+var PURS = '.purs';
+
+var MODULE_RE = /(?:^|\n)module\s+([\w\.]+)/;
+
+function PurescriptWebpackPlugin(options) {
+  this.options = Object.assign({
+    src: [
+      path.join('src', '**', '*.purs'),
+      path.join('bower_components', 'purescript-*', 'src', '**', '*.purs')
+    ],
+    ffi: [
+      path.join('src', '**', '*.js'),
+      path.join('bower_components', 'purescript-*', 'src', '**', '*.js')
+    ],
+    output: 'output',
+    bundleOutput: path.join('output', 'bundle.js'),
+    bundleNamespace: 'PS'
+  }, options);
+
+  this.context = {};
+}
+
+PurescriptWebpackPlugin.prototype.bundleModuleNames = function(){
+  var entries = this.context.bundleEntries;
+
+  var modules = this.context.compilation.modules;
+
+  var moduleNames = entries.map(function(entry){
+    var module_ = modules.filter(function(module_){
+      return module_.rawRequest === entry.request;
+    });
+
+    if (!module_[0]) return null;
+    else {
+      var file = module_[0].resource;
+
+      var contents = fs.readFileSync(file, {encoding: 'utf-8'});
+
+      var match = contents.match(MODULE_RE);
+
+      if (match === null) return null;
+      else {
+        return match[1];
+      }
+    }
+  });
+
+  var nonNullNames = moduleNames.filter(function(name){ return name !== null; });
+
+  return nonNullNames;
+};
+
+PurescriptWebpackPlugin.prototype.bundle = function(callback){
+  var moduleNames = this.bundleModuleNames();
+
+  if (moduleNames.length === 0) callback("No entry point module names found.", null);
+  else {
+    var moduleArgs = moduleNames.reduce(function(b, a){ return b.concat(['-m', a]); }, []);
+
+    var args = moduleArgs.concat([
+      '-n', this.options.bundleNamespace,
+      '-r', REQUIRE_PATH,
+      path.join(this.options.output, '**', 'index.js'),
+      path.join(this.options.output, '**', 'foreign.js')
+    ]);
+
+    var psc = child_process.spawn(PSC_BUNDLE, args);
+
+    var stdout = '';
+
+    var stderr = '';
+
+    psc.stdout.on('data', function(data){
+      stdout = stdout + data.toString();
+    });
+
+    psc.stderr.on('data', function(data){
+      stderr = stderr + data.toString();
+    });
+
+    psc.on('close', function(code){
+      var error = code !== 0 ? stderr : null;
+      callback(error, stdout);
+    });
+  }
+};
+
+PurescriptWebpackPlugin.prototype.compile = function(callback){
+  var ffiArgs = this.options.ffi.reduce(function(b, a){ return b.concat(['-f', a]); }, []);
+
+  var args = ffiArgs.concat([
+    '-o', this.options.output,
+    '-r', REQUIRE_PATH
+  ]).concat(this.options.src);
+
+  var psc = child_process.spawn(PSC, args);
+
+  var stderr = '';
+
+  psc.stderr.on('data', function(data){
+    stderr = stderr + data.toString();
+  });
+
+  psc.on('close', function(code){
+    var error = code !== 0 ? stderr : null;
+    callback(error);
+  });
+};
+
+PurescriptWebpackPlugin.prototype.apply = function(compiler){
+  var plugin = this;
+
+  compiler.plugin('compilation', function(compilation, params){
+    Object.assign(plugin.context, {
+      requiresCompiling: true,
+      bundleEntries: [],
+      callbacks: [],
+      compilation: null,
+      compile: function(callback){
+        return function(){
+          var callbacks = plugin.context.callbacks;
+          callbacks.push(callback);
+
+          if (plugin.context.requiresCompiling) {
+            plugin.context.requiresCompiling = false;
+            plugin.compile(function(error){
+              if (error) callbacks.forEach(function(callback){callback(error)()});
+              else {
+                plugin.bundle(function(error, result){
+                  var result_ = result + 'module.exports = ' + plugin.options.bundleNamespace + ';';
+                  fs.writeFile(plugin.options.bundleOutput, result_, function(error_){
+                    callbacks.forEach(function(callback){callback(error_ || error)()});
+                  });
+                });
+              }
+            });
+          }
+        };
+      }
+    });
+
+    compilation.plugin('normal-module-loader', function(loaderContext, module){
+      if (path.extname(module.userRequest) === PURS) {
+        plugin.context.compilation = compilation;
+        loaderContext.purescriptWebpackPluginContext = plugin.context;
+      }
+    });
+  });
+
+  compiler.plugin('normal-module-factory', function(normalModuleFactory){
+    normalModuleFactory.plugin('before-resolve', function(data, callback){
+      if (path.extname(data.request) === PURS) {
+        plugin.context.bundleEntries.push(data);
+      }
+      callback(null, data);
+    });
+  });
+};
+
+module.exports = PurescriptWebpackPlugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
   "name": "purescript-webpack-plugin",
   "version": "0.1.0",
-  "private": true,
-  "files": []
+  "description": "PureScript plugin for webpack",
+  "license": "MIT",
+  "repository": "ethul/purescript-webpack-plugin",
+  "author": {
+    "name": "Eric Thul",
+    "email": "thul.eric@gmail.com"
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
The PureScript webpack plugin handles compiling the PureScript files in
a project and bundles the result using `psc-bundle`. The bundle becomes
a webpack dependency and is referenced by the shim modules generated by
the `purs-loader`.
