### PR TITLE
Adding dependency tracking for src and FFI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+npm_debug.log
 node_modules/
 tmp/

--- a/dependency-graph.js
+++ b/dependency-graph.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var acorn = require('acorn');
+
+var walk = require('acorn/dist/walk');
+
+var dependencyGraph = require('dependency-graph');
+
+function onAssignmentExpression(namespace) {
+  function handler(node, state) {
+    if (node.operator === '=') {
+      if (node.left.type === 'MemberExpression' && node.left.object.name === namespace) {
+        if (node.right.type === 'LogicalExpression' && node.right.left.object.name === namespace) {
+          var value = node.left.property.value;
+          if (!state.modules[value]) {
+            state.modules[value] = state.cache;
+          }
+          else {
+            var existing = state.modules[value];
+            state.modules[value] = {
+              src: existing.src.concat(state.cache.src),
+              ffi: existing.ffi.concat(state.cache.ffi)
+            }
+          }
+          state.cache = {src: [], ffi: []};
+        }
+      }
+    }
+  }
+
+  return handler;
+}
+
+function onVariableDeclarator(namespace) {
+  function handler(node, state) {
+    if (node.id.type === 'Identifier' &&
+        node.init.type === 'MemberExpression' &&
+        node.init.object.type === 'Identifier' &&
+        node.init.object.name === namespace) {
+      var value = node.init.property.value;
+      if (node.id.name === '$foreign') {
+        state.cache.ffi.push(value);
+      }
+      else {
+        state.cache.src.push(value);
+      }
+    }
+  }
+
+  return handler;
+}
+
+function insertFromBundle(bundle, namespace, graph, callback) {
+  var ast = acorn.parse(bundle, {ecmaVersion: 5});
+
+  var state = {modules: {}, cache: {src: [], ffi: []}};
+
+  walk.simple(ast, {
+    AssignmentExpression: onAssignmentExpression(namespace),
+    VariableDeclarator: onVariableDeclarator(namespace)
+  }, null, state);
+
+  Object.keys(state.modules).forEach(function(key){
+    graph.addNode(key);
+    state.modules[key].src.forEach(function(dependency){
+      graph.addNode(dependency);
+      graph.addDependency(key, dependency);
+    });
+  });
+
+  callback(null, graph);
+}
+module.exports.insertFromBundle = insertFromBundle;
+
+function emptyGraph() {
+  return new dependencyGraph.DepGraph();
+}
+module.exports.emptyGraph = emptyGraph;

--- a/dependency-map.js
+++ b/dependency-map.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var path = require('path');
+
+var globby = require('globby');
+
+var immutable = require('immutable');
+
+var moduleParser = require('./module-parser');
+
+var cwd = process.cwd();
+
+function insertGlobs(parser, globs, map, callback) {
+  var promise =
+    globby(globs).then(function(files){
+      return files.reduce(function(b, a){
+        var name = parser(a);
+        return name !== null ? b.set(name, path.join(cwd, a)) : b;
+      }, map);
+    })
+  ;
+
+  promise.then(
+    function(result){callback(null, result)},
+    function(error){callback(error, null)}
+  );
+}
+
+function emptyMap() {
+  return immutable.Map();
+}
+module.exports.emptyMap = emptyMap;
+
+function insertSrcGlobs(srcGlobs, map, callback) {
+  insertGlobs(moduleParser.srcNameSync, srcGlobs, map, callback);
+}
+module.exports.insertSrcGlobs = insertSrcGlobs;
+
+function insertFFIGlobs(ffiGlobs, map, callback) {
+  insertGlobs(moduleParser.ffiNameSync, ffiGlobs, map, callback);
+}
+module.exports.insertFFIGlobs = insertFFIGlobs;

--- a/module-parser.js
+++ b/module-parser.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var fs = require('fs');
+
+var SRC_RE = /(?:^|\n)module\s+([\w\.]+)/;
+
+var FFI_RE = /(?:^|\n)\/\/\s+module\s+([\w\.]+)/;
+
+function nameSync(regex, file) {
+  var contents = fs.readFileSync(file, {encoding: 'utf-8'});
+
+  var match = contents.match(regex);
+
+  return match === null ? null : match[1];
+}
+
+function srcNameSync(file) {
+  return nameSync(SRC_RE, file);
+}
+module.exports.srcNameSync = srcNameSync;
+
+function ffiNameSync(file) {
+  return nameSync(FFI_RE, file);
+}
+module.exports.ffiNameSync = ffiNameSync;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,15 @@
     "email": "thul.eric@gmail.com"
   },
   "files": [
-    "index.js"
-  ]
+    "index.js",
+    "dependency-graph.js",
+    "dependency-map.js",
+    "module-parser.js"
+  ],
+  "dependencies": {
+    "acorn": "^3.0.2",
+    "dependency-graph": "^0.4.1",
+    "globby": "^4.0.0",
+    "immutable": "^3.7.6"
+  }
 }


### PR DESCRIPTION
Initial implementation for computing the information necessary for
webpack to recognize transitive PureScript src and FFI dependencies.

Resolves ethul/purs-loader#37
