### PR TITLE
Add `useOutputAsError` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Specifies additional PureScript psc-bundle arguments. The default value is `{}`.
 
 Specifies whether PureScript bundle is used. The default value is `true`.
 
+###### `useOutputAsError` (Boolean)
+
+Use the compiler output as the error message passed to webpack.
+By default, a simple "PureScript compilation has failed." error is passed to
+webpack and the compiler output is written to stderr. This default behavior is
+undesirable if the compiler output is needed by webpack or webpack plugins.
+
 ## Example
 
 Refer to the [purescript-webpack-example](https://github.com/ethul/purescript-webpack-example) for an example.

--- a/index.js
+++ b/index.js
@@ -245,12 +245,19 @@ PurescriptWebpackPlugin.prototype.contextCompile = function(callback){
 
   return function(){
     var callbacks = plugin.context.callbacks;
+    var options = plugin.context.options;
 
     callbacks.push(callback);
 
     var invokeCallbacks = function(error, graph, output){
-      process.stderr.setEncoding('utf-8');
-      process.stderr.write(output);
+      if (!error || !options.useOutputAsError) {
+        process.stderr.setEncoding('utf-8');
+        process.stderr.write(output);
+      }
+
+      if (!options.useOutputAsError) {
+        error = new Error("PureScript compilation has failed.");
+      }
 
       callbacks.forEach(function(callback){
         callback(error)(graph)();
@@ -303,7 +310,8 @@ PurescriptWebpackPlugin.prototype.apply = function(compiler){
       bundleEntries: [],
       callbacks: [],
       compilation: null,
-      compile: plugin.contextCompile.bind(plugin)
+      compile: plugin.contextCompile.bind(plugin),
+      useOutputAsError: false,
     });
 
     compilation.plugin('normal-module-loader', function(loaderContext, module){


### PR DESCRIPTION
The `useOutputAsError` option uses the compiler output as the error message
passed to webpack. By default, a simple "PureScript compilation has failed."
error is passed to webpack and the compiler output is written to stderr. This
default behavior is undesirable if the compiler output is needed by webpack or
webpack plugins.

Solves the issues related to ethul/purescript-webpack-plugin#18 and ethul/purs-loader#40
