### PR TITLE
Push output and errors to the webpack compilation

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,11 +325,11 @@ PurescriptWebpackPlugin.prototype.apply = function(compiler){
 
   compiler.plugin('after-compile', function(compilation, callback){
     if (plugin.context.output) {
-      compilation.warnings.push('Compiler output\n\n' + plugin.context.output);
+      compilation.warnings.push('Compilation Result\n\n' + plugin.context.output);
     }
 
     if (plugin.context.error) {
-      compilation.errors.push('Compiler error\n\n' + plugin.context.error);
+      compilation.errors.push('Compilation Result\n\n' + plugin.context.error);
     }
 
     callback();

--- a/index.js
+++ b/index.js
@@ -249,8 +249,8 @@ PurescriptWebpackPlugin.prototype.contextCompile = function(callback){
     callbacks.push(callback);
 
     var invokeCallbacks = function(error, graph, output){
-      process.stderr.setEncoding('utf-8');
-      process.stderr.write(output);
+      plugin.context.output = output;
+      plugin.context.error = error;
 
       callbacks.forEach(function(callback){
         callback(error)(graph)();
@@ -321,6 +321,18 @@ PurescriptWebpackPlugin.prototype.apply = function(compiler){
       }
       callback(null, data);
     });
+  });
+
+  compiler.plugin('after-compile', function(compilation, callback){
+    if (plugin.context.output) {
+      compilation.warnings.push('Compiler output\n\n' + plugin.context.output);
+    }
+
+    if (plugin.context.error) {
+      compilation.errors.push('Compiler error\n\n' + plugin.context.error);
+    }
+
+    callback();
   });
 };
 


### PR DESCRIPTION
The PureScript output is now added to the warnings array in the webpack
compilation. Also, any PureScript error is added to the errors array in
the webpack compilation.

This allows for tools such as `psa` to transform the error/output, and
it also allows for the browser to display errors during hot reloading.

Resolves #18
