### PR TITLE
Fix duplicate errors and warnings during multiple compiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,12 +245,18 @@ PurescriptWebpackPlugin.prototype.contextCompile = function(callback){
 
   return function(){
     var callbacks = plugin.context.callbacks;
+    var compilation = plugin.context.compilation;
 
     callbacks.push(callback);
 
-    var invokeCallbacks = function(error, graph, output){
-      plugin.context.output = output;
-      plugin.context.error = error;
+    var invokeCallbacks = function(error, graph, output) {
+      if (output) {
+        compilation.warnings.push('Compilation Result\n\n' + output);
+      }
+
+      if (error) {
+        compilation.errors.push('Compilation Result\n\n' + error);
+      }
 
       callbacks.forEach(function(callback){
         callback(error)(graph)();
@@ -321,18 +327,6 @@ PurescriptWebpackPlugin.prototype.apply = function(compiler){
       }
       callback(null, data);
     });
-  });
-
-  compiler.plugin('after-compile', function(compilation, callback){
-    if (plugin.context.output) {
-      compilation.warnings.push('Compilation Result\n\n' + plugin.context.output);
-    }
-
-    if (plugin.context.error) {
-      compilation.errors.push('Compilation Result\n\n' + plugin.context.error);
-    }
-
-    callback();
   });
 };
 


### PR DESCRIPTION
This prevents duplicate errors and warnings when multiple webpack compilations
are triggered but not multiple purescript compilations. Essentially, when in watch mode `after-emit` was being called more times than purescript compilations were occuring. This ensures that warnings and errors from the compilation are added only when the purescript compilation occurs.
